### PR TITLE
Feature/enhance swig build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 
-option(BUILD_PYTHON "Build Python SWIG module" ON)
+option(BUILD_PYTHON "Build Python SWIG module" OFF)
 if(BUILD_PYTHON)
     add_subdirectory(src/swig/python)
 endif()

--- a/jenkins/install.sh
+++ b/jenkins/install.sh
@@ -1,4 +1,4 @@
 mkdir -p /OpenDB/build
 cd /OpenDB/build
-cmake ..
+cmake -DBUILD_PYTHON=ON -DBUILD_TCL=ON ..
 make

--- a/src/swig/tcl/CMakeLists.txt
+++ b/src/swig/tcl/CMakeLists.txt
@@ -1,8 +1,7 @@
-add_executable(opendbtcl
-    ${PROJECT_SOURCE_DIR}/src/swig/tcl/main.cpp
+# Library
+add_library(opendbtcl
     ${CMAKE_CURRENT_BINARY_DIR}/opendb_wrap.cpp
 )
-
 target_compile_features(opendbtcl PRIVATE cxx_auto_type)
 target_compile_options(opendbtcl PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall>)
 
@@ -21,7 +20,6 @@ target_link_libraries(opendbtcl
         tcl
 )
 
-# enable swig compile
 set (OPENDB_SWIG_FILES
     ${PROJECT_SOURCE_DIR}/src/swig/tcl/opendbtcl.i
     ${PROJECT_SOURCE_DIR}/src/swig/tcl/dbtypes.i
@@ -32,4 +30,31 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/opendb_wrap.cpp
   COMMAND ${SWIG_EXECUTABLE} -tcl8 -c++ -Iinclude/opendb -o ${CMAKE_CURRENT_BINARY_DIR}/opendb_wrap.cpp ${PROJECT_SOURCE_DIR}/src/swig/tcl/opendbtcl.i
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   DEPENDS ${OPENDB_SWIG_FILES}
+)
+
+# Executable
+add_executable(opendbtcl-bin
+    ${PROJECT_SOURCE_DIR}/src/swig/tcl/main.cpp
+)
+
+target_compile_features(opendbtcl-bin PRIVATE cxx_auto_type)
+target_compile_options(opendbtcl-bin PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall>)
+
+target_include_directories(opendbtcl-bin
+    PUBLIC
+        $<INSTALL_INTERFACE:include/opendb>
+        ${PROJECT_SOURCE_DIR}/include/opendb
+        ${PROJECT_SOURCE_DIR}/include/lef56
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/swig/tcl
+)
+
+target_link_libraries(opendbtcl-bin
+    PUBLIC
+        opendbtcl
+)
+
+set_target_properties(opendbtcl-bin
+    PROPERTIES 
+        OUTPUT_NAME opendbtcl
 )


### PR DESCRIPTION
- This allows TCL to be linked as a library. The `opendbtcl` executable is still there with no change.
- It turns off building python wrappers by default. Users would need to explicitly specify it `cmake -DBUILD_PYTHON=ON ..`