### PR TITLE
Feature/rename helper methods

### DIFF
--- a/src/swig/tcl/dbenums.i
+++ b/src/swig/tcl/dbenums.i
@@ -1,22 +1,31 @@
 
 %typemap(out) odb::dbOrientType, dbOrientType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbOrientType::Value::R0) {
-		obj = Tcl_NewStringObj("R0", -1);
-	} else if ($1.getValue() == odb::dbOrientType::Value::R90) {
-		obj = Tcl_NewStringObj("R90", -1);
-	} else if ($1.getValue() == odb::dbOrientType::Value::R180) {
-		obj = Tcl_NewStringObj("R180", -1);
-	} else if ($1.getValue() == odb::dbOrientType::Value::R270) {
-		obj = Tcl_NewStringObj("R270", -1);
-	} else if ($1.getValue() == odb::dbOrientType::Value::MY) {
-		obj = Tcl_NewStringObj("MY", -1);
-	} else if ($1.getValue() == odb::dbOrientType::Value::MYR90) {
-		obj = Tcl_NewStringObj("MYR90", -1);
-	} else if ($1.getValue() == odb::dbOrientType::Value::MX) {
-		obj = Tcl_NewStringObj("MX", -1);
-	} else if ($1.getValue() == odb::dbOrientType::Value::MXR90) {
-		obj = Tcl_NewStringObj("MXR90", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbOrientType::Value::R0:
+			obj = Tcl_NewStringObj("R0", -1);
+			break;
+	 	case odb::dbOrientType::Value::R90:
+			obj = Tcl_NewStringObj("R90", -1);
+			break;
+	 	case odb::dbOrientType::Value::R180:
+			obj = Tcl_NewStringObj("R180", -1);
+			break;
+	 	case odb::dbOrientType::Value::R270:
+			obj = Tcl_NewStringObj("R270", -1);
+			break;
+	 	case odb::dbOrientType::Value::MY:
+			obj = Tcl_NewStringObj("MY", -1);
+			break;
+	 	case odb::dbOrientType::Value::MYR90:
+			obj = Tcl_NewStringObj("MYR90", -1);
+			break;
+	 	case odb::dbOrientType::Value::MX:
+			obj = Tcl_NewStringObj("MX", -1);
+			break;
+	 	case odb::dbOrientType::Value::MXR90:
+			obj = Tcl_NewStringObj("MXR90", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -69,23 +78,32 @@
 	}
 }
 %typemap(out) odb::dbSigType, dbSigType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbSigType::Value::SIGNAL) {
-		obj = Tcl_NewStringObj("SIGNAL", -1);
-	} else if ($1.getValue() == odb::dbSigType::Value::POWER) {
-		obj = Tcl_NewStringObj("POWER", -1);
-	} else if ($1.getValue() == odb::dbSigType::Value::GROUND) {
-		obj = Tcl_NewStringObj("GROUND", -1);
-	} else if ($1.getValue() == odb::dbSigType::Value::CLOCK) {
-		obj = Tcl_NewStringObj("CLOCK", -1);
-	} else if ($1.getValue() == odb::dbSigType::Value::ANALOG) {
-		obj = Tcl_NewStringObj("ANALOG", -1);
-	} else if ($1.getValue() == odb::dbSigType::Value::RESET) {
-		obj = Tcl_NewStringObj("RESET", -1);
-	} else if ($1.getValue() == odb::dbSigType::Value::SCAN) {
-		obj = Tcl_NewStringObj("SCAN", -1);
-	} else if ($1.getValue() == odb::dbSigType::Value::TIEOFF) {
-		obj = Tcl_NewStringObj("TIEOFF", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbSigType::Value::SIGNAL:
+			obj = Tcl_NewStringObj("SIGNAL", -1);
+			break;
+	 	case odb::dbSigType::Value::POWER:
+			obj = Tcl_NewStringObj("POWER", -1);
+			break;
+	 	case odb::dbSigType::Value::GROUND:
+			obj = Tcl_NewStringObj("GROUND", -1);
+			break;
+	 	case odb::dbSigType::Value::CLOCK:
+			obj = Tcl_NewStringObj("CLOCK", -1);
+			break;
+	 	case odb::dbSigType::Value::ANALOG:
+			obj = Tcl_NewStringObj("ANALOG", -1);
+			break;
+	 	case odb::dbSigType::Value::RESET:
+			obj = Tcl_NewStringObj("RESET", -1);
+			break;
+	 	case odb::dbSigType::Value::SCAN:
+			obj = Tcl_NewStringObj("SCAN", -1);
+			break;
+	 	case odb::dbSigType::Value::TIEOFF:
+			obj = Tcl_NewStringObj("TIEOFF", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -138,15 +156,20 @@
 	}
 }
 %typemap(out) odb::dbIoType, dbIoType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbIoType::Value::INPUT) {
-		obj = Tcl_NewStringObj("INPUT", -1);
-	} else if ($1.getValue() == odb::dbIoType::Value::OUTPUT) {
-		obj = Tcl_NewStringObj("OUTPUT", -1);
-	} else if ($1.getValue() == odb::dbIoType::Value::INOUT) {
-		obj = Tcl_NewStringObj("INOUT", -1);
-	} else if ($1.getValue() == odb::dbIoType::Value::FEEDTHRU) {
-		obj = Tcl_NewStringObj("FEEDTHRU", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbIoType::Value::INPUT:
+			obj = Tcl_NewStringObj("INPUT", -1);
+			break;
+	 	case odb::dbIoType::Value::OUTPUT:
+			obj = Tcl_NewStringObj("OUTPUT", -1);
+			break;
+	 	case odb::dbIoType::Value::INOUT:
+			obj = Tcl_NewStringObj("INOUT", -1);
+			break;
+	 	case odb::dbIoType::Value::FEEDTHRU:
+			obj = Tcl_NewStringObj("FEEDTHRU", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -183,21 +206,29 @@
 	}
 }
 %typemap(out) odb::dbPlacementStatus, dbPlacementStatus {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbPlacementStatus::Value::NONE) {
-		obj = Tcl_NewStringObj("NONE", -1);
-	} else if ($1.getValue() == odb::dbPlacementStatus::Value::UNPLACED) {
-		obj = Tcl_NewStringObj("UNPLACED", -1);
-	} else if ($1.getValue() == odb::dbPlacementStatus::Value::SUGGESTED) {
-		obj = Tcl_NewStringObj("SUGGESTED", -1);
-	} else if ($1.getValue() == odb::dbPlacementStatus::Value::PLACED) {
-		obj = Tcl_NewStringObj("PLACED", -1);
-	} else if ($1.getValue() == odb::dbPlacementStatus::Value::LOCKED) {
-		obj = Tcl_NewStringObj("LOCKED", -1);
-	} else if ($1.getValue() == odb::dbPlacementStatus::Value::FIRM) {
-		obj = Tcl_NewStringObj("FIRM", -1);
-	} else if ($1.getValue() == odb::dbPlacementStatus::Value::COVER) {
-		obj = Tcl_NewStringObj("COVER", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbPlacementStatus::Value::NONE:
+			obj = Tcl_NewStringObj("NONE", -1);
+			break;
+	 	case odb::dbPlacementStatus::Value::UNPLACED:
+			obj = Tcl_NewStringObj("UNPLACED", -1);
+			break;
+	 	case odb::dbPlacementStatus::Value::SUGGESTED:
+			obj = Tcl_NewStringObj("SUGGESTED", -1);
+			break;
+	 	case odb::dbPlacementStatus::Value::PLACED:
+			obj = Tcl_NewStringObj("PLACED", -1);
+			break;
+	 	case odb::dbPlacementStatus::Value::LOCKED:
+			obj = Tcl_NewStringObj("LOCKED", -1);
+			break;
+	 	case odb::dbPlacementStatus::Value::FIRM:
+			obj = Tcl_NewStringObj("FIRM", -1);
+			break;
+	 	case odb::dbPlacementStatus::Value::COVER:
+			obj = Tcl_NewStringObj("COVER", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -246,51 +277,74 @@
 	}
 }
 %typemap(out) odb::dbMasterType, dbMasterType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbMasterType::Value::NONE) {
-		obj = Tcl_NewStringObj("NONE", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::COVER) {
-		obj = Tcl_NewStringObj("COVER", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::RING) {
-		obj = Tcl_NewStringObj("RING", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::BLOCK) {
-		obj = Tcl_NewStringObj("BLOCK", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::PAD) {
-		obj = Tcl_NewStringObj("PAD", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::PAD_INPUT) {
-		obj = Tcl_NewStringObj("PAD_INPUT", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::PAD_OUTPUT) {
-		obj = Tcl_NewStringObj("PAD_OUTPUT", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::PAD_INOUT) {
-		obj = Tcl_NewStringObj("PAD_INOUT", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::PAD_POWER) {
-		obj = Tcl_NewStringObj("PAD_POWER", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::PAD_SPACER) {
-		obj = Tcl_NewStringObj("PAD_SPACER", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::CORE) {
-		obj = Tcl_NewStringObj("CORE", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::CORE_FEEDTHRU) {
-		obj = Tcl_NewStringObj("CORE_FEEDTHRU", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::CORE_TIEHIGH) {
-		obj = Tcl_NewStringObj("CORE_TIEHIGH", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::CORE_TIELOW) {
-		obj = Tcl_NewStringObj("CORE_TIELOW", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::CORE_SPACER) {
-		obj = Tcl_NewStringObj("CORE_SPACER", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::ENDCAP) {
-		obj = Tcl_NewStringObj("ENDCAP", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::ENDCAP_PRE) {
-		obj = Tcl_NewStringObj("ENDCAP_PRE", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::ENDCAP_POST) {
-		obj = Tcl_NewStringObj("ENDCAP_POST", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::ENDCAP_TOPLEFT) {
-		obj = Tcl_NewStringObj("ENDCAP_TOPLEFT", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::ENDCAP_TOPRIGHT) {
-		obj = Tcl_NewStringObj("ENDCAP_TOPRIGHT", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::ENDCAP_BOTTOMLEFT) {
-		obj = Tcl_NewStringObj("ENDCAP_BOTTOMLEFT", -1);
-	} else if ($1.getValue() == odb::dbMasterType::Value::ENDCAP_BOTTOMRIGHT) {
-		obj = Tcl_NewStringObj("ENDCAP_BOTTOMRIGHT", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbMasterType::Value::NONE:
+			obj = Tcl_NewStringObj("NONE", -1);
+			break;
+	 	case odb::dbMasterType::Value::COVER:
+			obj = Tcl_NewStringObj("COVER", -1);
+			break;
+	 	case odb::dbMasterType::Value::RING:
+			obj = Tcl_NewStringObj("RING", -1);
+			break;
+	 	case odb::dbMasterType::Value::BLOCK:
+			obj = Tcl_NewStringObj("BLOCK", -1);
+			break;
+	 	case odb::dbMasterType::Value::PAD:
+			obj = Tcl_NewStringObj("PAD", -1);
+			break;
+	 	case odb::dbMasterType::Value::PAD_INPUT:
+			obj = Tcl_NewStringObj("PAD_INPUT", -1);
+			break;
+	 	case odb::dbMasterType::Value::PAD_OUTPUT:
+			obj = Tcl_NewStringObj("PAD_OUTPUT", -1);
+			break;
+	 	case odb::dbMasterType::Value::PAD_INOUT:
+			obj = Tcl_NewStringObj("PAD_INOUT", -1);
+			break;
+	 	case odb::dbMasterType::Value::PAD_POWER:
+			obj = Tcl_NewStringObj("PAD_POWER", -1);
+			break;
+	 	case odb::dbMasterType::Value::PAD_SPACER:
+			obj = Tcl_NewStringObj("PAD_SPACER", -1);
+			break;
+	 	case odb::dbMasterType::Value::CORE:
+			obj = Tcl_NewStringObj("CORE", -1);
+			break;
+	 	case odb::dbMasterType::Value::CORE_FEEDTHRU:
+			obj = Tcl_NewStringObj("CORE_FEEDTHRU", -1);
+			break;
+	 	case odb::dbMasterType::Value::CORE_TIEHIGH:
+			obj = Tcl_NewStringObj("CORE_TIEHIGH", -1);
+			break;
+	 	case odb::dbMasterType::Value::CORE_TIELOW:
+			obj = Tcl_NewStringObj("CORE_TIELOW", -1);
+			break;
+	 	case odb::dbMasterType::Value::CORE_SPACER:
+			obj = Tcl_NewStringObj("CORE_SPACER", -1);
+			break;
+	 	case odb::dbMasterType::Value::ENDCAP:
+			obj = Tcl_NewStringObj("ENDCAP", -1);
+			break;
+	 	case odb::dbMasterType::Value::ENDCAP_PRE:
+			obj = Tcl_NewStringObj("ENDCAP_PRE", -1);
+			break;
+	 	case odb::dbMasterType::Value::ENDCAP_POST:
+			obj = Tcl_NewStringObj("ENDCAP_POST", -1);
+			break;
+	 	case odb::dbMasterType::Value::ENDCAP_TOPLEFT:
+			obj = Tcl_NewStringObj("ENDCAP_TOPLEFT", -1);
+			break;
+	 	case odb::dbMasterType::Value::ENDCAP_TOPRIGHT:
+			obj = Tcl_NewStringObj("ENDCAP_TOPRIGHT", -1);
+			break;
+	 	case odb::dbMasterType::Value::ENDCAP_BOTTOMLEFT:
+			obj = Tcl_NewStringObj("ENDCAP_BOTTOMLEFT", -1);
+			break;
+	 	case odb::dbMasterType::Value::ENDCAP_BOTTOMRIGHT:
+			obj = Tcl_NewStringObj("ENDCAP_BOTTOMRIGHT", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -399,19 +453,26 @@
 	}
 }
 %typemap(out) odb::dbTechLayerType, dbTechLayerType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbTechLayerType::Value::ROUTING) {
-		obj = Tcl_NewStringObj("ROUTING", -1);
-	} else if ($1.getValue() == odb::dbTechLayerType::Value::CUT) {
-		obj = Tcl_NewStringObj("CUT", -1);
-	} else if ($1.getValue() == odb::dbTechLayerType::Value::MASTERSLICE) {
-		obj = Tcl_NewStringObj("MASTERSLICE", -1);
-	} else if ($1.getValue() == odb::dbTechLayerType::Value::OVERLAP) {
-		obj = Tcl_NewStringObj("OVERLAP", -1);
-	} else if ($1.getValue() == odb::dbTechLayerType::Value::IMPLANT) {
-		obj = Tcl_NewStringObj("IMPLANT", -1);
-	} else if ($1.getValue() == odb::dbTechLayerType::Value::NONE) {
-		obj = Tcl_NewStringObj("NONE", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbTechLayerType::Value::ROUTING:
+			obj = Tcl_NewStringObj("ROUTING", -1);
+			break;
+	 	case odb::dbTechLayerType::Value::CUT:
+			obj = Tcl_NewStringObj("CUT", -1);
+			break;
+	 	case odb::dbTechLayerType::Value::MASTERSLICE:
+			obj = Tcl_NewStringObj("MASTERSLICE", -1);
+			break;
+	 	case odb::dbTechLayerType::Value::OVERLAP:
+			obj = Tcl_NewStringObj("OVERLAP", -1);
+			break;
+	 	case odb::dbTechLayerType::Value::IMPLANT:
+			obj = Tcl_NewStringObj("IMPLANT", -1);
+			break;
+	 	case odb::dbTechLayerType::Value::NONE:
+			obj = Tcl_NewStringObj("NONE", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -456,13 +517,17 @@
 	}
 }
 %typemap(out) odb::dbTechLayerDir, dbTechLayerDir {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbTechLayerDir::Value::NONE) {
-		obj = Tcl_NewStringObj("NONE", -1);
-	} else if ($1.getValue() == odb::dbTechLayerDir::Value::HORIZONTAL) {
-		obj = Tcl_NewStringObj("HORIZONTAL", -1);
-	} else if ($1.getValue() == odb::dbTechLayerDir::Value::VERTICAL) {
-		obj = Tcl_NewStringObj("VERTICAL", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbTechLayerDir::Value::NONE:
+			obj = Tcl_NewStringObj("NONE", -1);
+			break;
+	 	case odb::dbTechLayerDir::Value::HORIZONTAL:
+			obj = Tcl_NewStringObj("HORIZONTAL", -1);
+			break;
+	 	case odb::dbTechLayerDir::Value::VERTICAL:
+			obj = Tcl_NewStringObj("VERTICAL", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -495,11 +560,14 @@
 	}
 }
 %typemap(out) odb::dbRowDir, dbRowDir {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbRowDir::Value::HORIZONTAL) {
-		obj = Tcl_NewStringObj("HORIZONTAL", -1);
-	} else if ($1.getValue() == odb::dbRowDir::Value::VERTICAL) {
-		obj = Tcl_NewStringObj("VERTICAL", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbRowDir::Value::HORIZONTAL:
+			obj = Tcl_NewStringObj("HORIZONTAL", -1);
+			break;
+	 	case odb::dbRowDir::Value::VERTICAL:
+			obj = Tcl_NewStringObj("VERTICAL", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -528,33 +596,47 @@
 	}
 }
 %typemap(out) odb::dbBoxOwner, dbBoxOwner {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbBoxOwner::Value::UNKNOWN) {
-		obj = Tcl_NewStringObj("UNKNOWN", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::BLOCK) {
-		obj = Tcl_NewStringObj("BLOCK", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::INST) {
-		obj = Tcl_NewStringObj("INST", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::BTERM) {
-		obj = Tcl_NewStringObj("BTERM", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::VIA) {
-		obj = Tcl_NewStringObj("VIA", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::OBSTRUCTION) {
-		obj = Tcl_NewStringObj("OBSTRUCTION", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::SWIRE) {
-		obj = Tcl_NewStringObj("SWIRE", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::BLOCKAGE) {
-		obj = Tcl_NewStringObj("BLOCKAGE", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::MASTER) {
-		obj = Tcl_NewStringObj("MASTER", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::MPIN) {
-		obj = Tcl_NewStringObj("MPIN", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::TECH_VIA) {
-		obj = Tcl_NewStringObj("TECH_VIA", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::REGION) {
-		obj = Tcl_NewStringObj("REGION", -1);
-	} else if ($1.getValue() == odb::dbBoxOwner::Value::BPIN) {
-		obj = Tcl_NewStringObj("BPIN", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbBoxOwner::Value::UNKNOWN:
+			obj = Tcl_NewStringObj("UNKNOWN", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::BLOCK:
+			obj = Tcl_NewStringObj("BLOCK", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::INST:
+			obj = Tcl_NewStringObj("INST", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::BTERM:
+			obj = Tcl_NewStringObj("BTERM", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::VIA:
+			obj = Tcl_NewStringObj("VIA", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::OBSTRUCTION:
+			obj = Tcl_NewStringObj("OBSTRUCTION", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::SWIRE:
+			obj = Tcl_NewStringObj("SWIRE", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::BLOCKAGE:
+			obj = Tcl_NewStringObj("BLOCKAGE", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::MASTER:
+			obj = Tcl_NewStringObj("MASTER", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::MPIN:
+			obj = Tcl_NewStringObj("MPIN", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::TECH_VIA:
+			obj = Tcl_NewStringObj("TECH_VIA", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::REGION:
+			obj = Tcl_NewStringObj("REGION", -1);
+			break;
+	 	case odb::dbBoxOwner::Value::BPIN:
+			obj = Tcl_NewStringObj("BPIN", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -627,15 +709,20 @@
 	}
 }
 %typemap(out) odb::dbPolygonOwner, dbPolygonOwner {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbPolygonOwner::Value::UNKNOWN) {
-		obj = Tcl_NewStringObj("UNKNOWN", -1);
-	} else if ($1.getValue() == odb::dbPolygonOwner::Value::BPIN) {
-		obj = Tcl_NewStringObj("BPIN", -1);
-	} else if ($1.getValue() == odb::dbPolygonOwner::Value::OBSTRUCTION) {
-		obj = Tcl_NewStringObj("OBSTRUCTION", -1);
-	} else if ($1.getValue() == odb::dbPolygonOwner::Value::SWIRE) {
-		obj = Tcl_NewStringObj("SWIRE", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbPolygonOwner::Value::UNKNOWN:
+			obj = Tcl_NewStringObj("UNKNOWN", -1);
+			break;
+	 	case odb::dbPolygonOwner::Value::BPIN:
+			obj = Tcl_NewStringObj("BPIN", -1);
+			break;
+	 	case odb::dbPolygonOwner::Value::OBSTRUCTION:
+			obj = Tcl_NewStringObj("OBSTRUCTION", -1);
+			break;
+	 	case odb::dbPolygonOwner::Value::SWIRE:
+			obj = Tcl_NewStringObj("SWIRE", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -672,19 +759,26 @@
 	}
 }
 %typemap(out) odb::dbWireType, dbWireType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbWireType::Value::NONE) {
-		obj = Tcl_NewStringObj("NONE", -1);
-	} else if ($1.getValue() == odb::dbWireType::Value::COVER) {
-		obj = Tcl_NewStringObj("COVER", -1);
-	} else if ($1.getValue() == odb::dbWireType::Value::FIXED) {
-		obj = Tcl_NewStringObj("FIXED", -1);
-	} else if ($1.getValue() == odb::dbWireType::Value::ROUTED) {
-		obj = Tcl_NewStringObj("ROUTED", -1);
-	} else if ($1.getValue() == odb::dbWireType::Value::SHIELD) {
-		obj = Tcl_NewStringObj("SHIELD", -1);
-	} else if ($1.getValue() == odb::dbWireType::Value::NOSHIELD) {
-		obj = Tcl_NewStringObj("NOSHIELD", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbWireType::Value::NONE:
+			obj = Tcl_NewStringObj("NONE", -1);
+			break;
+	 	case odb::dbWireType::Value::COVER:
+			obj = Tcl_NewStringObj("COVER", -1);
+			break;
+	 	case odb::dbWireType::Value::FIXED:
+			obj = Tcl_NewStringObj("FIXED", -1);
+			break;
+	 	case odb::dbWireType::Value::ROUTED:
+			obj = Tcl_NewStringObj("ROUTED", -1);
+			break;
+	 	case odb::dbWireType::Value::SHIELD:
+			obj = Tcl_NewStringObj("SHIELD", -1);
+			break;
+	 	case odb::dbWireType::Value::NOSHIELD:
+			obj = Tcl_NewStringObj("NOSHIELD", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -729,31 +823,44 @@
 	}
 }
 %typemap(out) odb::dbWireShapeType, dbWireShapeType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbWireShapeType::Value::NONE) {
-		obj = Tcl_NewStringObj("NONE", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::RING) {
-		obj = Tcl_NewStringObj("RING", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::PADRING) {
-		obj = Tcl_NewStringObj("PADRING", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::BLOCKRING) {
-		obj = Tcl_NewStringObj("BLOCKRING", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::STRIPE) {
-		obj = Tcl_NewStringObj("STRIPE", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::FOLLOWPIN) {
-		obj = Tcl_NewStringObj("FOLLOWPIN", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::IOWIRE) {
-		obj = Tcl_NewStringObj("IOWIRE", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::COREWIRE) {
-		obj = Tcl_NewStringObj("COREWIRE", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::BLOCKWIRE) {
-		obj = Tcl_NewStringObj("BLOCKWIRE", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::BLOCKAGEWIRE) {
-		obj = Tcl_NewStringObj("BLOCKAGEWIRE", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::FILLWIRE) {
-		obj = Tcl_NewStringObj("FILLWIRE", -1);
-	} else if ($1.getValue() == odb::dbWireShapeType::Value::DRCFILL) {
-		obj = Tcl_NewStringObj("DRCFILL", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbWireShapeType::Value::NONE:
+			obj = Tcl_NewStringObj("NONE", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::RING:
+			obj = Tcl_NewStringObj("RING", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::PADRING:
+			obj = Tcl_NewStringObj("PADRING", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::BLOCKRING:
+			obj = Tcl_NewStringObj("BLOCKRING", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::STRIPE:
+			obj = Tcl_NewStringObj("STRIPE", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::FOLLOWPIN:
+			obj = Tcl_NewStringObj("FOLLOWPIN", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::IOWIRE:
+			obj = Tcl_NewStringObj("IOWIRE", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::COREWIRE:
+			obj = Tcl_NewStringObj("COREWIRE", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::BLOCKWIRE:
+			obj = Tcl_NewStringObj("BLOCKWIRE", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::BLOCKAGEWIRE:
+			obj = Tcl_NewStringObj("BLOCKAGEWIRE", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::FILLWIRE:
+			obj = Tcl_NewStringObj("FILLWIRE", -1);
+			break;
+	 	case odb::dbWireShapeType::Value::DRCFILL:
+			obj = Tcl_NewStringObj("DRCFILL", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -822,13 +929,17 @@
 	}
 }
 %typemap(out) odb::dbSiteClass, dbSiteClass {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbSiteClass::Value::NONE) {
-		obj = Tcl_NewStringObj("NONE", -1);
-	} else if ($1.getValue() == odb::dbSiteClass::Value::PAD) {
-		obj = Tcl_NewStringObj("PAD", -1);
-	} else if ($1.getValue() == odb::dbSiteClass::Value::CORE) {
-		obj = Tcl_NewStringObj("CORE", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbSiteClass::Value::NONE:
+			obj = Tcl_NewStringObj("NONE", -1);
+			break;
+	 	case odb::dbSiteClass::Value::PAD:
+			obj = Tcl_NewStringObj("PAD", -1);
+			break;
+	 	case odb::dbSiteClass::Value::CORE:
+			obj = Tcl_NewStringObj("CORE", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -861,11 +972,14 @@
 	}
 }
 %typemap(out) odb::dbOnOffType, dbOnOffType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbOnOffType::Value::OFF) {
-		obj = Tcl_NewStringObj("OFF", -1);
-	} else if ($1.getValue() == odb::dbOnOffType::Value::ON) {
-		obj = Tcl_NewStringObj("ON", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbOnOffType::Value::OFF:
+			obj = Tcl_NewStringObj("OFF", -1);
+			break;
+	 	case odb::dbOnOffType::Value::ON:
+			obj = Tcl_NewStringObj("ON", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -894,11 +1008,14 @@
 	}
 }
 %typemap(out) odb::dbClMeasureType, dbClMeasureType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbClMeasureType::Value::EUCLIDEAN) {
-		obj = Tcl_NewStringObj("EUCLIDEAN", -1);
-	} else if ($1.getValue() == odb::dbClMeasureType::Value::MAXXY) {
-		obj = Tcl_NewStringObj("MAXXY", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbClMeasureType::Value::EUCLIDEAN:
+			obj = Tcl_NewStringObj("EUCLIDEAN", -1);
+			break;
+	 	case odb::dbClMeasureType::Value::MAXXY:
+			obj = Tcl_NewStringObj("MAXXY", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -927,15 +1044,20 @@
 	}
 }
 %typemap(out) odb::dbJournalEntryType, dbJournalEntryType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbJournalEntryType::Value::NONE) {
-		obj = Tcl_NewStringObj("NONE", -1);
-	} else if ($1.getValue() == odb::dbJournalEntryType::Value::OWNER) {
-		obj = Tcl_NewStringObj("OWNER", -1);
-	} else if ($1.getValue() == odb::dbJournalEntryType::Value::ADD) {
-		obj = Tcl_NewStringObj("ADD", -1);
-	} else if ($1.getValue() == odb::dbJournalEntryType::Value::DESTROY) {
-		obj = Tcl_NewStringObj("DESTROY", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbJournalEntryType::Value::NONE:
+			obj = Tcl_NewStringObj("NONE", -1);
+			break;
+	 	case odb::dbJournalEntryType::Value::OWNER:
+			obj = Tcl_NewStringObj("OWNER", -1);
+			break;
+	 	case odb::dbJournalEntryType::Value::ADD:
+			obj = Tcl_NewStringObj("ADD", -1);
+			break;
+	 	case odb::dbJournalEntryType::Value::DESTROY:
+			obj = Tcl_NewStringObj("DESTROY", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -972,17 +1094,23 @@
 	}
 }
 %typemap(out) odb::dbDirection, dbDirection {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbDirection::Value::NONE) {
-		obj = Tcl_NewStringObj("NONE", -1);
-	} else if ($1.getValue() == odb::dbDirection::Value::NORTH) {
-		obj = Tcl_NewStringObj("NORTH", -1);
-	} else if ($1.getValue() == odb::dbDirection::Value::EAST) {
-		obj = Tcl_NewStringObj("EAST", -1);
-	} else if ($1.getValue() == odb::dbDirection::Value::SOUTH) {
-		obj = Tcl_NewStringObj("SOUTH", -1);
-	} else if ($1.getValue() == odb::dbDirection::Value::WEST) {
-		obj = Tcl_NewStringObj("WEST", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbDirection::Value::NONE:
+			obj = Tcl_NewStringObj("NONE", -1);
+			break;
+	 	case odb::dbDirection::Value::NORTH:
+			obj = Tcl_NewStringObj("NORTH", -1);
+			break;
+	 	case odb::dbDirection::Value::EAST:
+			obj = Tcl_NewStringObj("EAST", -1);
+			break;
+	 	case odb::dbDirection::Value::SOUTH:
+			obj = Tcl_NewStringObj("SOUTH", -1);
+			break;
+	 	case odb::dbDirection::Value::WEST:
+			obj = Tcl_NewStringObj("WEST", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -1023,13 +1151,17 @@
 	}
 }
 %typemap(out) odb::dbRegionType, dbRegionType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbRegionType::Value::INCLUSIVE) {
-		obj = Tcl_NewStringObj("INCLUSIVE", -1);
-	} else if ($1.getValue() == odb::dbRegionType::Value::EXCLUSIVE) {
-		obj = Tcl_NewStringObj("EXCLUSIVE", -1);
-	} else if ($1.getValue() == odb::dbRegionType::Value::SUGGESTED) {
-		obj = Tcl_NewStringObj("SUGGESTED", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbRegionType::Value::INCLUSIVE:
+			obj = Tcl_NewStringObj("INCLUSIVE", -1);
+			break;
+	 	case odb::dbRegionType::Value::EXCLUSIVE:
+			obj = Tcl_NewStringObj("EXCLUSIVE", -1);
+			break;
+	 	case odb::dbRegionType::Value::SUGGESTED:
+			obj = Tcl_NewStringObj("SUGGESTED", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }
@@ -1062,19 +1194,26 @@
 	}
 }
 %typemap(out) odb::dbSourceType, dbSourceType {
-	Tcl_Obj *obj;
-	if ($1.getValue() == odb::dbSourceType::Value::NONE) {
-		obj = Tcl_NewStringObj("NONE", -1);
-	} else if ($1.getValue() == odb::dbSourceType::Value::NETLIST) {
-		obj = Tcl_NewStringObj("NETLIST", -1);
-	} else if ($1.getValue() == odb::dbSourceType::Value::DIST) {
-		obj = Tcl_NewStringObj("DIST", -1);
-	} else if ($1.getValue() == odb::dbSourceType::Value::USER) {
-		obj = Tcl_NewStringObj("USER", -1);
-	} else if ($1.getValue() == odb::dbSourceType::Value::TIMING) {
-		obj = Tcl_NewStringObj("TIMING", -1);
-	} else if ($1.getValue() == odb::dbSourceType::Value::TEST) {
-		obj = Tcl_NewStringObj("TEST", -1);
+	Tcl_Obj *obj = nullptr;
+	switch ($1.getValue()) {
+		case odb::dbSourceType::Value::NONE:
+			obj = Tcl_NewStringObj("NONE", -1);
+			break;
+	 	case odb::dbSourceType::Value::NETLIST:
+			obj = Tcl_NewStringObj("NETLIST", -1);
+			break;
+	 	case odb::dbSourceType::Value::DIST:
+			obj = Tcl_NewStringObj("DIST", -1);
+			break;
+	 	case odb::dbSourceType::Value::USER:
+			obj = Tcl_NewStringObj("USER", -1);
+			break;
+	 	case odb::dbSourceType::Value::TIMING:
+			obj = Tcl_NewStringObj("TIMING", -1);
+			break;
+	 	case odb::dbSourceType::Value::TEST:
+			obj = Tcl_NewStringObj("TEST", -1);
+			break;
 	}
 	Tcl_SetObjResult(interp, obj);
 }

--- a/src/swig/tcl/dbhelpers.i
+++ b/src/swig/tcl/dbhelpers.i
@@ -76,18 +76,18 @@ odb_read_design(odb::dbDatabase* db, std::vector<std::string> def_path)
     return chip;
 }
 
-int     write_def(odb::dbBlock* block, const char* path, odb::defout::Version version = odb::defout::Version::DEF_5_5) {
+int     odb_write_def(odb::dbBlock* block, const char* path, odb::defout::Version version = odb::defout::Version::DEF_5_5) {
     defout writer;
     writer.setVersion(version);
     return writer.writeBlock(block, path);
 }
-int     write_lef(odb::dbLib* lib, const char* path) {
+int     odb_write_lef(odb::dbLib* lib, const char* path) {
     lefout writer;
     return writer.writeTechAndLib(lib, path);
 }
 
 odb::dbDatabase*
-import_db(odb::dbDatabase* db, const char* db_path)
+odb_import_db(odb::dbDatabase* db, const char* db_path)
 {
     if (db == NULL) {
         db = odb::dbDatabase::create();
@@ -105,7 +105,7 @@ import_db(odb::dbDatabase* db, const char* db_path)
 }
 
 int
-export_db(odb::dbDatabase* db, const char* db_path)
+odb_export_db(odb::dbDatabase* db, const char* db_path)
 {
     FILE *fp = fopen(db_path, "wb");
     if (!fp) {
@@ -124,7 +124,7 @@ odb::dbChip*     odb_read_def(odb::dbDatabase* db, std::vector<std::string> path
 odb::dbChip*     odb_read_def(std::vector<odb::dbLib*>& libs, std::vector<std::string> paths);
 odb::dbChip*     odb_read_design(odb::dbDatabase* db, std::vector<std::string> def_path);
 odb::dbChip*     odb_read_design(odb::dbDatabase* db, std::vector<std::string> lef_path, std::vector<std::string> def_path);
-int     write_def(odb::dbBlock* block, const char* path, odb::defout::Version version = odb::defout::Version::DEF_5_5);
-int     write_lef(odb::dbLib* lib, const char* path);
-odb::dbDatabase* import_db(odb::dbDatabase* db, const char* db_path);
-int         export_db(odb::dbDatabase* db, const char* db_path);
+int     odb_write_def(odb::dbBlock* block, const char* path, odb::defout::Version version = odb::defout::Version::DEF_5_5);
+int     odb_write_lef(odb::dbLib* lib, const char* path);
+odb::dbDatabase* odb_import_db(odb::dbDatabase* db, const char* db_path);
+int         odb_export_db(odb::dbDatabase* db, const char* db_path);

--- a/src/swig/tcl/dbhelpers.i
+++ b/src/swig/tcl/dbhelpers.i
@@ -1,7 +1,7 @@
 %{
 #include <libgen.h>
 odb::dbLib*
-read_lef(odb::dbDatabase* db, const char* path)
+odb_read_lef(odb::dbDatabase* db, const char* path)
 {
     if (db == NULL) {
         db = dbDatabase::create();
@@ -16,7 +16,7 @@ read_lef(odb::dbDatabase* db, const char* path)
 }
 
 std::vector<odb::dbLib*>
-read_lef(odb::dbDatabase* db, std::vector<std::string> paths)
+odb_read_lef(odb::dbDatabase* db, std::vector<std::string> paths)
 {
     if (db == NULL) {
         db = dbDatabase::create();
@@ -24,13 +24,13 @@ read_lef(odb::dbDatabase* db, std::vector<std::string> paths)
     std::vector<odb::dbLib*> libs;
 
     for (std::string &path: paths) {
-        libs.push_back(read_lef(db, path.c_str()));
+        libs.push_back(odb_read_lef(db, path.c_str()));
     }
     return libs;
 }
 
 odb::dbChip*
-read_def(std::vector<odb::dbLib*>& libs, std::vector<std::string> paths)
+odb_read_def(std::vector<odb::dbLib*>& libs, std::vector<std::string> paths)
 {
     if (paths.size() != 1) {
         fprintf(stderr, "Only one DEF file should be provided.\n");
@@ -46,33 +46,33 @@ read_def(std::vector<odb::dbLib*>& libs, std::vector<std::string> paths)
 }
 
 odb::dbChip*
-read_def(odb::dbDatabase* db, std::vector<std::string> paths)
+odb_read_def(odb::dbDatabase* db, std::vector<std::string> paths)
 {
     std::vector<odb::dbLib *> libs;
     for (auto it = db->getLibs().begin(); it != db->getLibs().end(); it++) {
         libs.push_back(*it);
     }
-    return read_def(libs, paths);
+    return odb_read_def(libs, paths);
 }
 
 odb::dbChip*
-read_design(odb::dbDatabase* db, std::vector<std::string> &lef_path, std::vector<std::string> def_path)
+odb_read_design(odb::dbDatabase* db, std::vector<std::string> &lef_path, std::vector<std::string> def_path)
 {
     if (db == NULL) {
         db = dbDatabase::create();
     }
-    auto libs = read_lef(db, lef_path);
-    dbChip *chip = read_def(libs, def_path);
+    auto libs = odb_read_lef(db, lef_path);
+    dbChip *chip = odb_read_def(libs, def_path);
     return chip;
 }
 
 odb::dbChip*
-read_design(odb::dbDatabase* db, std::vector<std::string> def_path)
+odb_read_design(odb::dbDatabase* db, std::vector<std::string> def_path)
 {
     if (db == NULL) {
         db = dbDatabase::create();
     }
-    dbChip *chip = read_def(db, def_path);
+    dbChip *chip = odb_read_def(db, def_path);
     return chip;
 }
 
@@ -119,11 +119,11 @@ export_db(odb::dbDatabase* db, const char* db_path)
     return 1;
 }
 %}
-std::vector<odb::dbLib*>     read_lef(odb::dbDatabase* db, std::vector<std::string> path);
-odb::dbChip*     read_def(odb::dbDatabase* db, std::vector<std::string> paths);
-odb::dbChip*     read_def(std::vector<odb::dbLib*>& libs, std::vector<std::string> paths);
-odb::dbChip*     read_design(odb::dbDatabase* db, std::vector<std::string> def_path);
-odb::dbChip*     read_design(odb::dbDatabase* db, std::vector<std::string> lef_path, std::vector<std::string> def_path);
+std::vector<odb::dbLib*>     odb_read_lef(odb::dbDatabase* db, std::vector<std::string> path);
+odb::dbChip*     odb_read_def(odb::dbDatabase* db, std::vector<std::string> paths);
+odb::dbChip*     odb_read_def(std::vector<odb::dbLib*>& libs, std::vector<std::string> paths);
+odb::dbChip*     odb_read_design(odb::dbDatabase* db, std::vector<std::string> def_path);
+odb::dbChip*     odb_read_design(odb::dbDatabase* db, std::vector<std::string> lef_path, std::vector<std::string> def_path);
 int     write_def(odb::dbBlock* block, const char* path, odb::defout::Version version = odb::defout::Version::DEF_5_5);
 int     write_lef(odb::dbLib* lib, const char* path);
 odb::dbDatabase* import_db(odb::dbDatabase* db, const char* db_path);

--- a/tests/tcl/02-read_lef_test.tcl
+++ b/tests/tcl/02-read_lef_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set lib [read_lef $db ./OpenDB/tests/data/gscl45nm.lef]
+set lib [odb_read_lef $db ./OpenDB/tests/data/gscl45nm.lef]
 if {$lib == "NULL"} {
     puts "Failed to read LEF file"
     exit 1

--- a/tests/tcl/03-dump_via_rules_test.tcl
+++ b/tests/tcl/03-dump_via_rules_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set lib [read_lef $db ./OpenDB/tests/data/gscl45nm.lef]
+set lib [odb_read_lef $db ./OpenDB/tests/data/gscl45nm.lef]
 if {$lib == "NULL"} {
     exit 1
 }

--- a/tests/tcl/04-dump_vias_test.tcl
+++ b/tests/tcl/04-dump_vias_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set lib [read_lef $db ./OpenDB/tests/data/gscl45nm.lef]
+set lib [odb_read_lef $db ./OpenDB/tests/data/gscl45nm.lef]
 set tech [$lib getTech]
 set vias [$tech getVias]
 foreach via $vias {

--- a/tests/tcl/05-read_def_test.tcl
+++ b/tests/tcl/05-read_def_test.tcl
@@ -1,6 +1,6 @@
 set db [dbDatabase_create]
-set lib [read_lef $db ./OpenDB/tests/data/gscl45nm.lef]
-set chip [read_def $db "./OpenDB/tests/data/design.def"]
+set lib [odb_read_lef $db ./OpenDB/tests/data/gscl45nm.lef]
+set chip [odb_read_def $db "./OpenDB/tests/data/design.def"]
 if {$chip == "NULL"} {
     puts "Read DEF Failed"
     exit 1

--- a/tests/tcl/06-read_design_test.tcl
+++ b/tests/tcl/06-read_design_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set chip [read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
+set chip [odb_read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
 if {$chip == "NULL"} {
     puts "Read DEF Failed"
     exit 1

--- a/tests/tcl/07-dump_nets_test.tcl
+++ b/tests/tcl/07-dump_nets_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set chip [read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
+set chip [odb_read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
 set block [$chip getBlock]
 set nets [$block getNets]
 foreach net $nets {

--- a/tests/tcl/08-write_lef_and_def_test.tcl
+++ b/tests/tcl/08-write_lef_and_def_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set chip [read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
+set chip [odb_read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
 set lib [lindex [$db getLibs] 0]
 set block [$chip getBlock]
 set lef_write_result [write_lef $lib ./OpenDB/build/test.lef]

--- a/tests/tcl/08-write_lef_and_def_test.tcl
+++ b/tests/tcl/08-write_lef_and_def_test.tcl
@@ -2,11 +2,11 @@ set db [dbDatabase_create]
 set chip [odb_read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
 set lib [lindex [$db getLibs] 0]
 set block [$chip getBlock]
-set lef_write_result [write_lef $lib ./OpenDB/build/test.lef]
+set lef_write_result [odb_write_lef $lib ./OpenDB/build/test.lef]
 if {$lef_write_result != 1} {
     exit 1
 }
-set def_write_result [write_def $block ./OpenDB/build/test.def]
+set def_write_result [odb_write_def $block ./OpenDB/build/test.def]
 if {$def_write_result != 1} {
     exit 1
 }

--- a/tests/tcl/09-lef_data_access_test.tcl
+++ b/tests/tcl/09-lef_data_access_test.tcl
@@ -2,7 +2,7 @@ source [file join [file dirname [info script]] "test_helpers.tcl"]
 
 # Open database and load LEF
 set db [dbDatabase_create]
-set lib [read_lef $db ./OpenDB/tests/data/gscl45nm.lef]
+set lib [odb_read_lef $db ./OpenDB/tests/data/gscl45nm.lef]
 set tech [$lib getTech]
 # Basic LEF checks"
 check "lef version" {$tech getLefVersion} "5.5"

--- a/tests/tcl/10-gcd_def_access_test.tcl
+++ b/tests/tcl/10-gcd_def_access_test.tcl
@@ -3,7 +3,7 @@ source [file join [file dirname [info script]] "test_helpers.tcl"]
 # Open database, load lef and design
 
 set db [dbDatabase_create]
-set chip [read_design $db  ./OpenDB/tests/data/Nangate45/NangateOpenCellLibrary.mod.lef ./OpenDB/tests/data/gcd/floorplan.def]
+set chip [odb_read_design $db  ./OpenDB/tests/data/Nangate45/NangateOpenCellLibrary.mod.lef ./OpenDB/tests/data/gcd/floorplan.def]
 set lib [lindex [$db getLibs] 0]
 
 

--- a/tests/tcl/11-gcd_pdn_def_access_test.tcl
+++ b/tests/tcl/11-gcd_pdn_def_access_test.tcl
@@ -2,7 +2,7 @@ source [file join [file dirname [info script]] "test_helpers.tcl"]
 # Open database, load lef and design
 
 set db [dbDatabase_create]
-set chip [read_design $db  ./OpenDB/tests/data/Nangate45/NangateOpenCellLibrary.mod.lef ./OpenDB/tests/data/gcd/gcd_pdn.def]
+set chip [odb_read_design $db  ./OpenDB/tests/data/Nangate45/NangateOpenCellLibrary.mod.lef ./OpenDB/tests/data/gcd/gcd_pdn.def]
 
 set block [$chip getBlock]
 

--- a/tests/tcl/12-edit_def_test.tcl
+++ b/tests/tcl/12-edit_def_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set chip [read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
+set chip [odb_read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
 set lib [lindex [$db getLibs] 0]
 if {$chip == "NULL"} {
     puts "Read DEF Failed"

--- a/tests/tcl/13-wire_encoder_test.tcl
+++ b/tests/tcl/13-wire_encoder_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set chip [read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
+set chip [odb_read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
 set lib [lindex [$db getLibs] 0]
 set tech [$db getTech]
 if {$chip == "NULL"} {

--- a/tests/tcl/13-wire_encoder_test.tcl
+++ b/tests/tcl/13-wire_encoder_test.tcl
@@ -34,5 +34,5 @@ $wire_encoder newPath $jid2
 set jid3 [$wire_encoder addTechVia $via2]
 $wire_encoder end
 
-set result [write_def $block ./OpenDB/build/wire_encoder.def]
+set result [odb_write_def $block ./OpenDB/build/wire_encoder.def]
 exit [expr $result != 1]

--- a/tests/tcl/14-edit_via_params_test.tcl
+++ b/tests/tcl/14-edit_via_params_test.tcl
@@ -3,7 +3,7 @@ source [file join [file dirname [info script]] "test_helpers.tcl"]
 # Open database, load lef and design
 
 set db [dbDatabase_create]
-set chip [read_design $db  ./OpenDB/tests/data/Nangate45/NangateOpenCellLibrary.mod.lef ./OpenDB/tests/data/gcd/floorplan.def]
+set chip [odb_read_design $db  ./OpenDB/tests/data/Nangate45/NangateOpenCellLibrary.mod.lef ./OpenDB/tests/data/gcd/floorplan.def]
 set lib [lindex [$db getLibs] 0]
 
 # Block checks

--- a/tests/tcl/15-row_settings_test.tcl
+++ b/tests/tcl/15-row_settings_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set chip [read_design $db  ./OpenDB/tests/data/Nangate45/NangateOpenCellLibrary.mod.lef ./OpenDB/tests/data/gcd/floorplan.def]
+set chip [odb_read_design $db  ./OpenDB/tests/data/Nangate45/NangateOpenCellLibrary.mod.lef ./OpenDB/tests/data/gcd/floorplan.def]
 set lib [lindex [$db getLibs] 0]
 
 

--- a/tests/tcl/16-write_def_versions_test.tcl
+++ b/tests/tcl/16-write_def_versions_test.tcl
@@ -2,7 +2,7 @@ set db [dbDatabase_create]
 set chip [odb_read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
 set block [$chip getBlock]
 foreach version "DEF_5_3 DEF_5_4 DEF_5_5 DEF_5_6" {
-    set result [write_def $block ./OpenDB/build/test.def $version]
+    set result [odb_write_def $block ./OpenDB/build/test.def $version]
     if {[expr $result != 1]} {
         exit 1
     }
@@ -25,7 +25,7 @@ foreach version "DEF_5_3 DEF_5_4 DEF_5_5 DEF_5_6" {
 }
 # Test different syntax
 foreach version "5.3 5.4 5.5 5.6" {
-    set result [write_def $block ./OpenDB/build/test.def $version]
+    set result [odb_write_def $block ./OpenDB/build/test.def $version]
     if {[expr $result != 1]} {
         exit 1
     }

--- a/tests/tcl/16-write_def_versions_test.tcl
+++ b/tests/tcl/16-write_def_versions_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set chip [read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
+set chip [odb_read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
 set block [$chip getBlock]
 foreach version "DEF_5_3 DEF_5_4 DEF_5_5 DEF_5_6" {
     set result [write_def $block ./OpenDB/build/test.def $version]

--- a/tests/tcl/17-db_read-write_test.tcl
+++ b/tests/tcl/17-db_read-write_test.tcl
@@ -5,14 +5,14 @@ if {$chip == "NULL"} {
     exit 1
 }
 
-set export_result [export_db $db ./OpenDB/build/export.db]
+set export_result [odb_export_db $db ./OpenDB/build/export.db]
 if {$export_result != 1} {
     puts "Export DB failed"
     exit 1
 }
 
 set new_db [dbDatabase_create]
-import_db $new_db ./OpenDB/build/export.db
+odb_import_db $new_db ./OpenDB/build/export.db
 if {$new_db == "NULL"} {
     puts "Import DB Failed"
     exit 1

--- a/tests/tcl/17-db_read-write_test.tcl
+++ b/tests/tcl/17-db_read-write_test.tcl
@@ -1,5 +1,5 @@
 set db [dbDatabase_create]
-set chip [read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
+set chip [odb_read_design $db ./OpenDB/tests/data/gscl45nm.lef ./OpenDB/tests/data/design.def]
 if {$chip == "NULL"} {
     puts "Read DEF Failed"
     exit 1


### PR DESCRIPTION
- Added odb_ prefix for helper functions read_lef, read_def, read_design, write_lef, write_def, export_db, and import_db.
- Changed SWIG enum typemaps to use switch instead of if statements.