### PR TITLE
fix osx link; rm librt dependence, rm swig internal headers

### DIFF
--- a/src/db/CMakeLists.txt
+++ b/src/db/CMakeLists.txt
@@ -117,5 +117,4 @@ target_link_libraries(opendb
         lefin
     PRIVATE
         tcl
-        rt
 )

--- a/src/swig/tcl/opendbtcl.i
+++ b/src/swig/tcl/opendbtcl.i
@@ -11,7 +11,6 @@
 #include "defout.h"
 #include "dbExtControl.h"
 #include "dbViaParams.h"
-#include "dbtable2.h"
 #include "dbId.h"
 #include "dbRtEdge.h"
 #include "dbStream.h"
@@ -26,9 +25,7 @@
 #include "dbRtTree.h"
 #include "dbgdefines.h"
 #include "dbCCSegSet.h"
-#include "dbObject.h"
 #include "dbSet.h"
-#include "dbtable1.h"
 #include "dbTypes.h"
 #include "geom.h"
 using namespace odb;
@@ -62,7 +59,6 @@ using namespace odb;
 %include "dbExtControl.h"
 %include "dbViaParams.h"
 
-%include "dbtable2.h"
 %include "dbId.h"
 %include "dbRtEdge.h"
 %include "dbStream.h"
@@ -77,8 +73,6 @@ using namespace odb;
 %include "dbRtTree.h"
 %include "dbgdefines.h"
 %include "dbCCSegSet.h"
-%include "dbObject.h"
-%include "dbtable1.h"
 // Support file operations
 FILE *fopen(const char *name, const char *mode);
 int fclose(FILE *);


### PR DESCRIPTION
OpenDB does NOT depend on librt so it should not be linked against it.
dbObject.h is INTERNAL and has no business in the UI