### PR TITLE
Enhancement/db diff to file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@ configure_file (
     "${PROJECT_BINARY_DIR}/include/opendb/version.hh"
 )
 
-include_directories(/usr/include/tcl)
+find_package(TCL)
+include_directories(${TCL_INCLUDE_PATH})
 
 ############################################################################
 ################################# Targets ##################################

--- a/include/opendb/db.h
+++ b/include/opendb/db.h
@@ -566,7 +566,8 @@ class dbDatabase : public dbObject
     /// Returns true if differences were found.
     ///
     static bool diff( dbDatabase * db0, dbDatabase * db1, FILE * file, int indent_per_level );
-    
+    static bool diff( dbDatabase * db0, dbDatabase * db1, const char *diff_file,
+		      int indent_per_level );
     ///
     /// Translate a database-id back to a pointer.
     ///
@@ -2628,7 +2629,7 @@ class dbInst : public dbObject
     ///
     ///
     ///  MASTER COORDINATE SYSTEM:
-    ///
+   ///
     ///                                              |
     ///                                            --o-- (0,0)
     ///                                              |

--- a/src/db/dbDatabase.cpp
+++ b/src/db/dbDatabase.cpp
@@ -776,4 +776,15 @@ bool dbDatabase::diff( dbDatabase * db0_, dbDatabase * db1_, FILE * file, int in
     return diff.hasDifferences();
 }
 
+bool dbDatabase::diff( dbDatabase * db0, dbDatabase * db1,
+		       const char *diff_file, int indent_per_level )
+{
+  FILE *stream = fopen(diff_file, "w");
+  // diff supports NULL file args so no need to check the fopen result.
+  bool diffs = diff(db0, db1, stream, indent_per_level);
+  if (stream)
+    fclose(stream);
+  return diffs;
+}
+
 } // namespace

--- a/src/db/dbDatabase.cpp
+++ b/src/db/dbDatabase.cpp
@@ -779,8 +779,10 @@ bool dbDatabase::diff( dbDatabase * db0_, dbDatabase * db1_, FILE * file, int in
 bool dbDatabase::diff( dbDatabase * db0, dbDatabase * db1,
 		       const char *diff_file, int indent_per_level )
 {
-  FILE *stream = fopen(diff_file, "w");
-  // diff supports NULL file args so no need to check the fopen result.
+  FILE *stream = nullptr;
+  if (diff_file)
+    stream = fopen(diff_file, "w");
+  // diff supports nullptr file args so no need to check the fopen result.
   bool diffs = diff(db0, db1, stream, indent_per_level);
   if (stream)
     fclose(stream);

--- a/src/swig/python/opendbpy.i
+++ b/src/swig/python/opendbpy.i
@@ -78,9 +78,3 @@ using namespace odb;
 %include "dbgdefines.h"
 %include "dbCCSegSet.h"
 %include "dbSet.h"
-
-
-// Support file operations
-FILE *fopen(const char *name, const char *mode);
-int fclose(FILE *);
-int fgetc(FILE *);

--- a/src/swig/tcl/opendbtcl.i
+++ b/src/swig/tcl/opendbtcl.i
@@ -73,7 +73,3 @@ using namespace odb;
 %include "dbRtTree.h"
 %include "dbgdefines.h"
 %include "dbCCSegSet.h"
-// Support file operations
-FILE *fopen(const char *name, const char *mode);
-int fclose(FILE *);
-int fgetc(FILE *);

--- a/src/swig/tcl/opendbtcl.i
+++ b/src/swig/tcl/opendbtcl.i
@@ -2,7 +2,6 @@
 
 %{
 #define SWIG_FILE_WITH_INIT
-#include <stdio.h>
 #include "db.h"
 #include "dbShape.h"
 #include "lefin.h"

--- a/tests/python/17-db_read-write_test.py
+++ b/tests/python/17-db_read-write_test.py
@@ -24,10 +24,6 @@ new_db = odb.odb_import_db(new_db, os.path.join(opendb_dir, "build/export.db"))
 if new_db == None:
     exit("Import DB Failed")
 
-diff_file = open(os.path.join(opendb_dir, "build/db-export-import-diff.txt"), "w+")
-diff_file_content = diff_file.read()
-diff_file.close()
-
-if diff_file_content != "":
+diff_file = os.path.join(opendb_dir, "build/db-export-import-diff.txt")
+if odb.dbDatabase.diff(db, new_db, diff_file, 4):
     exit("Error: Difference found between exported and imported DB")
-    

--- a/tests/tcl/17-db_read-write_test.tcl
+++ b/tests/tcl/17-db_read-write_test.tcl
@@ -12,21 +12,17 @@ if {$chip == "NULL"} {
 }
 
 set export_result [odb_export_db $db $opendb_dir/build/export.db]
-if {$export_result != 1} {
+if {!$export_result} {
     puts "Export DB failed"
     exit 1
 }
 
 set new_db [dbDatabase_create]
 odb_import_db $new_db $opendb_dir/build/export.db
-if {$new_db == "NULL"} {
-    puts "Import DB Failed"
-    exit 1
-}
-set diff_file [fopen $opendb_dir/build/db-export-import-diff.txt w]
+
+set diff_file [file join $opendb_dir "build" "db-export-import-diff.txt"]
 set diff_rc [dbDatabase_diff $db $new_db $diff_file 4]
-fclose $diff_file
-if {$diff_rc != "0"} {
+if {$diff_rc} {
     puts "Database diff failed"
     exit 1
 }


### PR DESCRIPTION
add dbDatabase::diff to filename instead of FILE stream so tcl/python scripts do not required fopen/fclose (gag me)