### PR TITLE
add rt library in link libraries for old glibc

### DIFF
--- a/src/db/CMakeLists.txt
+++ b/src/db/CMakeLists.txt
@@ -113,6 +113,8 @@ target_link_libraries(opendb
         lefout
         zutil
         lefin
+	rt
     PRIVATE
         tcl
+	rt
 )


### PR DESCRIPTION
Hello, 
Building using old systems results to `undefined reference to 'clock_gettime`. 
According to this [link](https://stackoverflow.com/questions/2418157/c-error-undefined-reference-to-clock-gettime-and-clock-settime), Real time library is not linked and is linked started from glibc 2.17.
Adding rt to target_link_libraries solves this issue.