### PR TITLE
Enhancement/db def diff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 
-option(BUILD_PYTHON "Build Python SWIG module" OFF)
+option(BUILD_PYTHON "Build Python SWIG module" ON)
 if(BUILD_PYTHON)
     add_subdirectory(src/swig/python)
 endif()

--- a/include/opendb/db.h
+++ b/include/opendb/db.h
@@ -546,8 +546,6 @@ class dbDatabase : public dbObject
     /// Returns true if differences were found.
     ///
     static bool diff( dbDatabase * db0, dbDatabase * db1, FILE * file, int indent_per_level );
-    static bool diff( dbDatabase * db0, dbDatabase * db1, const char *diff_file,
-		      int indent_per_level );
     ///
     /// Translate a database-id back to a pointer.
     ///

--- a/src/db/dbDatabase.cpp
+++ b/src/db/dbDatabase.cpp
@@ -776,17 +776,4 @@ bool dbDatabase::diff( dbDatabase * db0_, dbDatabase * db1_, FILE * file, int in
     return diff.hasDifferences();
 }
 
-bool dbDatabase::diff( dbDatabase * db0, dbDatabase * db1,
-		       const char *diff_file, int indent_per_level )
-{
-  FILE *stream = nullptr;
-  if (diff_file)
-    stream = fopen(diff_file, "w");
-  // diff supports nullptr file args so no need to check the fopen result.
-  bool diffs = diff(db0, db1, stream, indent_per_level);
-  if (stream)
-    fclose(stream);
-  return diffs;
-}
-
 } // namespace

--- a/src/swig/python/opendbpy.i
+++ b/src/swig/python/opendbpy.i
@@ -52,6 +52,7 @@ using namespace odb;
 %include "dbenums.i"
 %include "dbhelpers.i"
 %include "parserenums.i"
+%include "../tcl/dbdiff.i"
 
 %include "geom.h"
 %include "dbObject.h"

--- a/src/swig/tcl/dbdiff.i
+++ b/src/swig/tcl/dbdiff.i
@@ -1,0 +1,65 @@
+%{
+
+bool
+db_diff(odb::dbDatabase *db1,
+	odb::dbDatabase *db2)
+{
+  // Sadly the diff report is too implementation specific to reveal much about
+  // the structural differences.
+  bool diffs = odb::dbDatabase::diff(db1, db2, nullptr, 2);
+  if (diffs) {
+    printf("Differences found.\n");
+    odb::dbChip *chip1 = db1->getChip();
+    odb::dbChip *chip2 = db2->getChip();
+    odb::dbBlock *block1 = chip1->getBlock();
+    odb::dbBlock *block2 = chip2->getBlock();
+
+    int inst_count1 = block1->getInsts().size();
+    int inst_count2 = block2->getInsts().size();
+    if (inst_count1 != inst_count2)
+      printf(" instances %d != %d.\n", inst_count1, inst_count2);
+
+    int pin_count1 = block1->getBTerms().size();
+    int pin_count2 = block2->getBTerms().size();
+    if (pin_count1 != pin_count2)
+      printf(" pins %d != %d.\n", pin_count1, pin_count2);
+
+    int net_count1 = block1->getNets().size();
+    int net_count2 = block2->getNets().size();
+    if (net_count1 != net_count2)
+      printf(" nets %d != %d.\n", net_count1, net_count2);
+  }
+  else
+    printf("No differences found.\n");
+  return diffs;
+}
+
+bool
+db_def_diff(odb::dbDatabase *db1,
+	    const char *def_filename)
+{
+  // Copy the database to get the tech and libraries.
+  odb::dbDatabase *db2 = odb::dbDatabase::duplicate(db1);
+  odb::dbChip *chip2 = db2->getChip();
+  if (chip2)
+    odb::dbChip::destroy(chip2);
+
+  odb::defin def_reader(db2);
+  std::vector<odb::dbLib *> search_libs;
+  for (odb::dbLib *lib : db2->getLibs())
+    search_libs.push_back(lib);
+  def_reader.createChip(search_libs, def_filename);
+  if (db2->getChip())
+    return db_diff(db1, db2);
+  else
+    return false;
+}
+
+%}
+
+bool
+db_diff(odb::dbDatabase *db1,
+	odb::dbDatabase *db2);
+bool
+db_def_diff(odb::dbDatabase *db1,
+	    const char *def_filename);

--- a/src/swig/tcl/dbhelpers.i
+++ b/src/swig/tcl/dbhelpers.i
@@ -1,3 +1,13 @@
+// The functions defined in this file are wrong on so many levels.
+// For example:
+// They are needlessly complicated by the use of string vector arguments
+// where multiple calls in the rare circumstances there are multiple lef
+// files would suffice. Why does odb_read_def use a vector of
+// def file names and then error if there is more than one?
+// Tcl is not polymorphic but there are multiple inline functions definitions
+// with the same name. A "NULL" db arg creates a database. What good is that?
+// I highly discourage their use. -cherry
+
 %{
 #include <libgen.h>
 odb::dbLib*
@@ -33,7 +43,7 @@ odb::dbChip*
 odb_read_def(std::vector<odb::dbLib*>& libs, std::vector<std::string> paths)
 {
     if (paths.size() != 1) {
-        fprintf(stderr, "Only one DEF file should be provided.\n");
+	fprintf(stderr, "Only one DEF file should be provided.\n");
         return NULL;
     }
     if (!libs.size()) {
@@ -118,7 +128,9 @@ odb_export_db(odb::dbDatabase* db, const char* db_path)
     fclose(fp);
     return 1;
 }
+
 %}
+
 std::vector<odb::dbLib*>     odb_read_lef(odb::dbDatabase* db, std::vector<std::string> path);
 odb::dbChip*     odb_read_def(odb::dbDatabase* db, std::vector<std::string> paths);
 odb::dbChip*     odb_read_def(std::vector<odb::dbLib*>& libs, std::vector<std::string> paths);

--- a/src/swig/tcl/opendbtcl.i
+++ b/src/swig/tcl/opendbtcl.i
@@ -44,11 +44,10 @@ using namespace odb;
 %include "dbenums.i"
 %include "parserenums.i"
 %include "dbtypes.i"
-
+%include "dbdiff.i"
 
 %include "geom.h"
 %include "db.h"
-
 
 %include "lefin.h"
 %include "lefout.h"

--- a/tests/python/17-db_read-write_test.py
+++ b/tests/python/17-db_read-write_test.py
@@ -24,6 +24,5 @@ new_db = odb.odb_import_db(new_db, os.path.join(opendb_dir, "build/export.db"))
 if new_db == None:
     exit("Import DB Failed")
 
-diff_file = os.path.join(opendb_dir, "build/db-export-import-diff.txt")
-if odb.dbDatabase.diff(db, new_db, diff_file, 4):
+if odb.db_diff(db, new_db):
     exit("Error: Difference found between exported and imported DB")

--- a/tests/tcl/17-db_read-write_test.tcl
+++ b/tests/tcl/17-db_read-write_test.tcl
@@ -20,14 +20,9 @@ if {!$export_result} {
 set new_db [dbDatabase_create]
 odb_import_db $new_db $opendb_dir/build/export.db
 
-set diff_file [file join $opendb_dir "build" "db-export-import-diff.txt"]
-set diff_rc [dbDatabase_diff $db $new_db $diff_file 4]
-if {$diff_rc} {
-    puts "Database diff failed"
-    exit 1
+if { [db_diff $db $new_db] } {
+  puts "Differences found between exported and imported db"
+  exit 1
 }
-if {[exec cat $opendb_dir/build/db-export-import-diff.txt] != ""} {
-    puts "Differences found between exported and imported db"
-    exit 1
-}
+
 exit 0


### PR DESCRIPTION
swig db_diff, db_def_diff primitives used by OpenROAD diff_def command to replace printing def files in regression results