### PR TITLE
Openroad on macOS/clang

### DIFF
--- a/include/opendb/ISdb.h
+++ b/include/opendb/ISdb.h
@@ -53,7 +53,7 @@ class dbBox;
 class dbBlock;
 class dbTech;
 class dbNet;
-
+class ZInterface;
 ///
 /// ISdb - Internal User Interface for ZRoute Area Search Infrastructure
 ///

--- a/include/opendb/ZInterface.h
+++ b/include/opendb/ZInterface.h
@@ -40,6 +40,7 @@
 
 #include "ZException.h"
 #include "odb.h"
+#include "dbObject.h"
 #include "geom.h"
 
 namespace odb {
@@ -47,7 +48,6 @@ namespace odb {
 class dbDatabase;
 class ZSession;
 class ZObject;
-class dbObject;
 
 /////////////////////////////////
 /// Event value types

--- a/include/opendb/ZNamespace.h
+++ b/include/opendb/ZNamespace.h
@@ -37,12 +37,12 @@
 #include <vector>
 
 #include "odb.h"
+#include "db.h"
 
 namespace odb {
 
 class ZObject;
 class dbDatabase;
-class dbObject;
 
 ////////////////////////////////////
 /// ZNamespace

--- a/include/opendb/dbExtControl.h
+++ b/include/opendb/dbExtControl.h
@@ -32,7 +32,14 @@
 
 #pragma once
 
-#include "db.h"
+// #include "db.h"
+#include <list>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "atypes.h"
+#include "dbObject.h"
 
 namespace odb {
 

--- a/include/opendb/dbObject.h
+++ b/include/opendb/dbObject.h
@@ -45,6 +45,7 @@ namespace odb {
 /// in dbObject.cpp
 ///
 class _dbDatabase;
+class dbDatabase;
 class dbOStream;
 class dbIStream;
 class dbObjectPage;
@@ -118,7 +119,7 @@ enum dbObjectType
   dbNameObj
 };
 
-class dbDatabase;
+//class dbDatabase;
 
 class dbObject
 {

--- a/src/db/dbBTerm.cpp
+++ b/src/db/dbBTerm.cpp
@@ -32,6 +32,7 @@
 
 #include "dbBTerm.h"
 
+#include "dbDatabase.h"
 #include "db.h"
 #include "dbArrayTable.h"
 #include "dbBPinItr.h"
@@ -39,7 +40,6 @@
 #include "dbBox.h"
 #include "dbBoxItr.h"
 #include "dbChip.h"
-#include "dbDatabase.h"
 #include "dbDiff.h"
 #include "dbDiff.hpp"
 #include "dbITerm.h"
@@ -48,6 +48,7 @@
 #include "dbTable.h"
 #include "dbTable.hpp"
 #include "dbTransform.h"
+#include "logger.h"
 
 namespace odb {
 

--- a/src/defin/create_box.cpp
+++ b/src/defin/create_box.cpp
@@ -31,6 +31,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "create_box.h"
+#include "logger.h"
+#include "db.h"
 
 namespace odb {
 

--- a/src/defin/definBlockage.cpp
+++ b/src/defin/definBlockage.cpp
@@ -38,6 +38,7 @@
 #include "dbShape.h"
 #include "definBlockage.h"
 #include "definPolygon.h"
+#include "logger.h"
 
 namespace odb {
 

--- a/src/defin/definComponent.cpp
+++ b/src/defin/definComponent.cpp
@@ -39,6 +39,7 @@
 #include "definComponent.h"
 #include "defiComponent.hpp"
 #include "defiUtil.hpp"
+#include "logger.h"
 
 namespace odb {
 

--- a/src/defin/definFill.cpp
+++ b/src/defin/definFill.cpp
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 #include "db.h"
 #include "dbShape.h"
+#include "logger.h"
 
 namespace odb {
 

--- a/src/defin/definGCell.cpp
+++ b/src/defin/definGCell.cpp
@@ -31,11 +31,12 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "definGCell.h"
+#include "db.h"
+#include "dbShape.h"
+#include "logger.h"
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "db.h"
-#include "dbShape.h"
 
 namespace odb {
 

--- a/src/defin/definNet.cpp
+++ b/src/defin/definNet.cpp
@@ -39,6 +39,8 @@
 #include "dbWireCodec.h"
 #include "definNet.h"
 
+#include "logger.h"
+
 namespace odb {
 
 inline uint get_net_dbid(const char* name)

--- a/src/defin/definNonDefaultRule.cpp
+++ b/src/defin/definNonDefaultRule.cpp
@@ -31,10 +31,11 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "definNonDefaultRule.h"
+#include "db.h"
+#include "logger.h"
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "db.h"
 
 namespace odb {
 

--- a/src/defin/definPin.cpp
+++ b/src/defin/definPin.cpp
@@ -37,6 +37,7 @@
 #include "db.h"
 #include "dbShape.h"
 #include "dbTransform.h"
+#include "logger.h"
 
 namespace odb {
 

--- a/src/defin/definPinProps.cpp
+++ b/src/defin/definPinProps.cpp
@@ -31,11 +31,12 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "definPinProps.h"
+#include "db.h"
+#include "logger.h"
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
-#include "db.h"
 
 namespace odb {
 

--- a/src/defin/definPropDefs.cpp
+++ b/src/defin/definPropDefs.cpp
@@ -30,8 +30,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "db.h"
 #include "definPropDefs.h"
+#include "db.h"
+#include "logger.h"
 
 namespace odb {
 

--- a/src/defin/definReader.cpp
+++ b/src/defin/definReader.cpp
@@ -53,6 +53,7 @@
 #include "definSNet.h"
 #include "definTracks.h"
 #include "definVia.h"
+#include "logger.h"
 
 #define UNSUPPORTED(msg)              \
   reader->error((msg));               \

--- a/src/defin/definRegion.cpp
+++ b/src/defin/definRegion.cpp
@@ -31,11 +31,12 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "definRegion.h"
+#include "db.h"
+#include "logger.h"
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
-#include "db.h"
 
 namespace odb {
 

--- a/src/defin/definRow.cpp
+++ b/src/defin/definRow.cpp
@@ -37,6 +37,7 @@
 #include "db.h"
 #include "dbShape.h"
 #include "definRow.h"
+#include "logger.h"
 
 namespace odb {
 

--- a/src/defin/definSNet.cpp
+++ b/src/defin/definSNet.cpp
@@ -39,6 +39,7 @@
 #include "dbShape.h"
 #include "definPolygon.h"
 #include "definSNet.h"
+#include "logger.h"
 
 namespace odb {
 

--- a/src/defin/definTracks.cpp
+++ b/src/defin/definTracks.cpp
@@ -31,11 +31,12 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "definTracks.h"
+#include "db.h"
+#include "dbShape.h"
+#include "logger.h"
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "db.h"
-#include "dbShape.h"
 
 namespace odb {
 

--- a/src/defin/definVia.cpp
+++ b/src/defin/definVia.cpp
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 #include "db.h"
 #include "dbShape.h"
+#include "logger.h"
 
 namespace odb {
 

--- a/src/defout/defout_impl.cpp
+++ b/src/defout/defout_impl.cpp
@@ -40,6 +40,7 @@
 #include "dbMap.h"
 #include "dbWireCodec.h"
 #include "defout_impl.h"
+#include "logger.h"
 
 namespace odb {
 

--- a/src/lefout/lefout.cpp
+++ b/src/lefout/lefout.cpp
@@ -30,11 +30,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <stdio.h>
-#include <algorithm>
+#include "lefout.h"
 #include "db.h"
 #include "dbTransform.h"
-#include "lefout.h"
+#include "logger.h"
+#include <algorithm>
+#include <stdio.h>
 
 using namespace odb;
 

--- a/src/swig/tcl/dbhelpers.i
+++ b/src/swig/tcl/dbhelpers.i
@@ -10,6 +10,7 @@
 
 %{
 #include <libgen.h>
+#include "../opendb/db.h"
 #include "lefin.h"
 #include "lefout.h"
 #include "defin.h"

--- a/src/swig/tcl/opendbtcl.i
+++ b/src/swig/tcl/opendbtcl.i
@@ -2,8 +2,10 @@
 
 %{
 #define SWIG_FILE_WITH_INIT
+#include "../opendb/db.h"
+#include "dbObject.h"
+#include "dbSet.h"
 #include "geom.h"
-#include "db.h"
 #include "dbShape.h"
 #include "dbViaParams.h"
 #include "dbRtEdge.h"
@@ -17,9 +19,7 @@
 #include "dbMap.h"
 #include "dbRtTree.h"
 #include "dbCCSegSet.h"
-#include "dbSet.h"
 #include "dbTypes.h"
-#include "geom.h"
 #include "wOrder.h"
 
 using namespace odb;


### PR DESCRIPTION
OpenDB does not compile on macOS/clang right out of the box. This PR introduces changes to that enables compilation. 
I was able to successfully build `OpenROAD-flow`  and run the complete flow for the gcd example on mac.

The RP does *not* introduce any functional change; only header "include"s have been modified.

- None of the changes are macOS specific. It should not affect build or run on Linux. I imagine at least some of the changes could also be necessary on some Linux platforms as well.

- One of the changes was system "db.h" was being picked up instead of the local "db.h", even though include was using quotes and not angle brackets.

- The PR probably needs some cleanup, as some of the changes were made through a trial and error process.

Tested on macOS 10.15.5 / Apple clang version 11.0.3 (clang-1103.0.32.59) (Xcode) / homebrew