### PR TITLE
Add find_package(spdlog) in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ configure_file (
     "${PROJECT_BINARY_DIR}/include/opendb/version.hh"
 )
 
+find_package(spdlog REQUIRED)
 find_package(TCL)
 
 find_package(Boost)

--- a/include/opendb/lefout.h
+++ b/include/opendb/lefout.h
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <string>
 
 #include "dbObject.h"
 #include "odb.h"


### PR DESCRIPTION
-This commit adds the find_package(spdlog) which was missing
in CMakeLists.txt according to issue #137: 
https://github.com/sheiny/OpenDB/blob/e0e98c4ab23094184598fa579d51ff2d1b897569/CMakeLists.txt#L18

-It also includes the #include <string> in lefout.h, since
the PR from issue #134 was not merged yet. Otherwise, I would
not be able to build the code on my machine.
https://github.com/sheiny/OpenDB/blob/e0e98c4ab23094184598fa579d51ff2d1b897569/include/opendb/lefout.h#L36

Please let me know if you need more information.

Thanks,
Sheiny